### PR TITLE
Fix behavior of library when the result of 'original_translate' is different of String

### DIFF
--- a/lib/dry_i18n.rb
+++ b/lib/dry_i18n.rb
@@ -7,28 +7,43 @@ module DryI18n
 
     def translate(locale, key, options = {})
       translation = original_translate(locale, key, options)
+
+      if translation.is_a? Array
+        translation.each_with_index do |translation_subpart, i|
+          translation[i] = replace_variable_in_translation(translation_subpart) if translation_subpart.is_a? String
+        end
+      elsif translation.is_a? String
+        translation = replace_variable_in_translation(translation)
+      end
+
+      translation
+    end
+
+    def replace_variable_in_translation(translation)
       variables = variables?(translation)
 
       if variables
         variables.each do |variable|
           key = variable[/@\[(.*?)\]/m, 1]
           options = key.scan(/\{.*?\}/)
+
           if options.any?
             options = eval(options.first)
             key = key.split(',').first
           else
             options = {}
           end
+
           translation = translation.sub(variable, I18n.translate(key, options))
         end
       end
+
       translation
     end
 
     private
 
       def variables?(translation)
-        return false unless translation =~ /\@\[.*?\]/
         nested_words = translation.scan(/\@\[.*?\]/)
         if !nested_words.any?
           false


### PR DESCRIPTION
@NachoPal 

When the result of `original_translate` 

https://github.com/NachoPal/dry_i18n/blob/6288d2c220b20038b85cee30c47c4ae574aff9c0/lib/dry_i18n.rb#L9

is different from` String`, the library does not work correctly.

I made a fix that provides a default behavior for all cases of return, maintaining the current behavior.

I suggest an urgent review, because it's a critical issue. Many gems, beyond Faker, do not work well together with `dry_i18n` because of this.

It closes #3 .

Thanks!